### PR TITLE
feat(scheduling): add scheduling options

### DIFF
--- a/apis/resourcestatemetrics/definition.yaml
+++ b/apis/resourcestatemetrics/definition.yaml
@@ -39,6 +39,15 @@ spec:
                               or a specific version tag.
                             type: string
                         type: object
+                      affinity:
+                        description: "Affinity scheduling rules for the pod. Supports nodeAffinity, podAffinity, and podAntiAffinity. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity"
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      nodeSelector:
+                        description: "Additional node selector terms to apply to the pod. These are merged with the default 'kubernetes.io/os: linux' selector. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector"
+                        type: object
+                        additionalProperties:
+                          x-kubernetes-preserve-unknown-fields: true
                       podMetadata:
                         description: "Pod's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
                         properties:
@@ -53,6 +62,12 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
+                      tolerations:
+                        description: "Tolerations for the pod. Allows the pod to be scheduled on nodes with matching taints. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/"
+                        type: array
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       replicas:
                         description: Number of controller replicas to run. Defaults to 1 for
                           high availability consider 2 or more.

--- a/functions/rsm/05-deployment.yaml.gotmpl
+++ b/functions/rsm/05-deployment.yaml.gotmpl
@@ -38,6 +38,17 @@ spec:
       serviceAccountName: resource-state-metrics
       nodeSelector:
         kubernetes.io/os: linux
+        {{- range $k, $v := $xr.spec.parameters.deployment.nodeSelector }}
+        {{ $k }}: {{ quote $v }}
+        {{- end }}
+      {{- with $xr.spec.parameters.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with $xr.spec.parameters.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: resource-state-metrics
         image: {{ $xr.spec.parameters.deployment.image.repository }}:{{ $xr.spec.parameters.deployment.image.tag }}

--- a/tests/test-rsm-scheduling/test.yaml.gotmpl
+++ b/tests/test-rsm-scheduling/test.yaml.gotmpl
@@ -1,0 +1,160 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+# This test validates that pod scheduling constraints (nodeSelector, tolerations,
+# affinity) are correctly rendered in the Deployment.
+
+items:
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: CompositionTest
+  metadata:
+    name: "rsm-scheduling"
+  spec:
+    compositionPath: "apis/resourcestatemetrics/composition.yaml"
+    xrdPath: "apis/resourcestatemetrics/definition.yaml"
+    xr:
+      apiVersion: metrics.crossplane.io/v1alpha1
+      kind: ResourceStateMetrics
+      metadata:
+        name: rsm
+      spec:
+        parameters:
+          namespace: resource-state-metrics
+          rbac:
+            allowedAPIGroups:
+              - apiextensions.crossplane.io
+              - metrics.crossplane.io
+              - pkg.crossplane.io
+              - aws.platform.upbound.io
+              - eks.aws.m.upbound.io
+          deployment:
+            replicas: 1
+            image:
+              repository: xpkg.crossplane.io/crossplane-contrib/resource-state-metrics-server
+              tag: v0.3.0
+            podMetadata:
+              labels:
+                example-label: example-label-value
+              annotations:
+                example-annotation: example-annotation-value
+            nodeSelector:
+              node-role.kubernetes.io/control-plane: ""
+            tolerations:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+                effect: NoSchedule
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 1
+                    preference:
+                      matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: Exists
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          service:
+            telemetryPort: 9998
+            metricsPort: 9999
+            type: ClusterIP
+    timeoutSeconds: 60
+    validate: false
+    assertResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: resource-state-metrics
+          namespace: resource-state-metrics
+          annotations:
+            crossplane.io/composition-resource-name: deployment
+          labels:
+            app.kubernetes.io/component: exporter
+            app.kubernetes.io/name: resource-state-metrics
+            app.kubernetes.io/version: "0.0.1"
+            crossplane.io/composite: rsm
+          ownerReferences:
+            - apiVersion: metrics.crossplane.io/v1alpha1
+              blockOwnerDeletion: true
+              controller: true
+              kind: ResourceStateMetrics
+              name: rsm
+              uid: ""
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: resource-state-metrics
+          template:
+            metadata:
+              annotations:
+                example-annotation: example-annotation-value
+              labels:
+                app.kubernetes.io/component: exporter
+                app.kubernetes.io/name: resource-state-metrics
+                app.kubernetes.io/version: "0.0.1"
+                example-label: example-label-value
+            spec:
+              automountServiceAccountToken: true
+              containers:
+                - name: resource-state-metrics
+                  image: "xpkg.crossplane.io/crossplane-contrib/resource-state-metrics-server:v0.3.0"
+                  args:
+                    - "--main-host=0.0.0.0"
+                    - "--main-port=9999"
+                    - "--self-host=0.0.0.0"
+                    - "--self-port=9998"
+                  ports:
+                    - containerPort: 9999
+                      name: http-metrics
+                    - containerPort: 9998
+                      name: telemetry
+                  livenessProbe:
+                    httpGet:
+                      path: /livez
+                      port: http-metrics
+                    initialDelaySeconds: 5
+                    timeoutSeconds: 5
+                  readinessProbe:
+                    httpGet:
+                      path: /readyz
+                      port: telemetry
+                    initialDelaySeconds: 5
+                    timeoutSeconds: 5
+                  resources:
+                    limits:
+                      cpu: "200m"
+                      memory: "256Mi"
+                    requests:
+                      cpu: "100m"
+                      memory: "128Mi"
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                    readOnlyRootFilesystem: true
+                    runAsNonRoot: true
+                    runAsUser: 65534
+                    seccompProfile:
+                      type: RuntimeDefault
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                          - key: node-role.kubernetes.io/control-plane
+                            operator: Exists
+                      weight: 1
+              nodeSelector:
+                kubernetes.io/os: linux
+                node-role.kubernetes.io/control-plane: ""
+              tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+              serviceAccountName: resource-state-metrics


### PR DESCRIPTION
- Add support for `tolerations`, `nodeSelector`, and `affinity` in the ResourceStateMetrics XRD under spec.parameters.deployment
- User-provided nodeSelector entries are merged with the default kubernetes.io/os: linux
tolerations and affinity are rendered via toYaml/nindent; schemas use x-kubernetes-preserve-unknown-fields for forward-compatibility
- Add a dedicated test-rsm-scheduling composition test with an inline XR validating all three scheduling fields